### PR TITLE
[feat] 내 주변 검색 (반경 10km) 기능 개발 완료 - 브라우저에서 위치 설정 해줘야 함

### DIFF
--- a/client/src/main/java/com/mc/app/service/AccomService.java
+++ b/client/src/main/java/com/mc/app/service/AccomService.java
@@ -69,13 +69,27 @@ public class AccomService implements MCService<Accommodations, Integer> {
         params.put("extras", extras);
         return accomRepository.searchAccommodationsByLocation(params);
     }
-
-    // 지역으로 숙소를 검색하는 메서드 (geolocation 기반)
-    public List<Accommodations> searchAccommodationsByGeoLocation(double latitude, double longitude, double radius) {
+    public List<AccomodationsWithRating> searchAccommodationsByGeoLocation(double latitude, double longitude, double radius, List<String> extras, boolean withRating) throws Exception {
         Map<String, Object> params = new HashMap<>();
         params.put("userLatitude", latitude);
         params.put("userLongitude", longitude);
         params.put("radius", radius);
-        return accomRepository.searchAccommodationsByGeoLocation(params);
+        params.put("extras", extras);
+        List<Accommodations> accommodations = accomRepository.searchAccommodationsByGeoLocation(params);
+
+        if (withRating) {
+            return getAccommodationsWithRating(accommodations);
+        } else {
+            List<AccomodationsWithRating> accommodationsWithRatingList = new ArrayList<>();
+            for (Accommodations acc : accommodations) {
+                AccomodationsWithRating dto = AccomodationsWithRating.builder()
+                        .accommodation(acc)
+                        .averageRating(0) // Or null, depending on your DTO
+                        .roundedRating(0)   // Or null
+                        .build();
+                accommodationsWithRatingList.add(dto);
+            }
+            return accommodationsWithRatingList;
+        }
     }
 }

--- a/client/src/main/java/com/mc/controller/SearchAccomController.java
+++ b/client/src/main/java/com/mc/controller/SearchAccomController.java
@@ -37,10 +37,14 @@ public class SearchAccomController {
     }
 
     @GetMapping("/search-accommodations-geo")
-    public List<Accommodations> searchAccommodationsByGeoLocation(
+    @ResponseBody
+    public List<AccomodationsWithRating> searchAccommodationsByGeoLocation(
             @RequestParam("latitude") double latitude,
             @RequestParam("longitude") double longitude,
-            @RequestParam("radius") double radius) {
-        return accomService.searchAccommodationsByGeoLocation(latitude, longitude, radius);
+            @RequestParam("radius") double radius,
+            @RequestParam(value = "extras[]", required = false) List<String> extras,
+            @RequestParam(value = "withRating", required = false, defaultValue = "false") boolean withRating
+    ) throws Exception {
+        return accomService.searchAccommodationsByGeoLocation(latitude, longitude, radius, extras, withRating);
     }
 }

--- a/client/src/main/resources/mapper/accomondationmapper.xml
+++ b/client/src/main/resources/mapper/accomondationmapper.xml
@@ -278,33 +278,40 @@
     <!-- 위치 기반 검색 -->
     <select id="searchAccommodationsByGeoLocation" parameterType="java.util.Map" resultType="com.mc.app.dto.Accommodations">
         SELECT
-            accommodation_id,
-            host_id,
-            name,
-            location,
-            price_night,
-            person_max,
-            description,
-            status,
-            category,
-            room_type,
-            breakfast,
-            pool,
-            barbecue,
-            pet,
-            latitude,
-            longitude,
-            image1_name,
-            image2_name,
-            image3_name,
-            image4_name,
-            image5_name,
-            create_day,
-            update_day
+        accommodation_id,
+        host_id,
+        name,
+        location,
+        price_night,
+        person_max,
+        description,
+        status,
+        category,
+        room_type,
+        breakfast,
+        pool,
+        barbecue,
+        pet,
+        latitude,
+        longitude,
+        image1_name,
+        image2_name,
+        image3_name,
+        image4_name,
+        image5_name,
+        create_day,
+        update_day
         FROM
-            Accommodations
+        Accommodations
         WHERE
-            ST_Distance_Sphere(POINT(longitude, latitude), POINT(#{userLongitude}, #{userLatitude})) &lt;= #{radius}
-          AND status = '활성'
+        ST_Distance_Sphere(POINT(longitude, latitude), POINT(#{userLongitude}, #{userLatitude})) &lt;= #{radius}
+        AND status = '활성'
+        <if test="extras != null and extras.size > 0">
+            AND (
+            <foreach collection="extras" item="extra" separator="OR">
+                ${extra} = TRUE
+            </foreach>
+            )
+        </if>
     </select>
 </mapper>

--- a/client/src/main/resources/static/js/custom.js
+++ b/client/src/main/resources/static/js/custom.js
@@ -337,37 +337,54 @@ $(document).ready(function () {
     }
 
     // 9. Geolocation
-
-    // 위치 정보 가져오기 버튼 이벤트 리스너
+// 위치 정보 가져오기 버튼 이벤트 리스너
     $("#geolocationBtn").on("click", function () {
         if (navigator.geolocation) {
-            navigator.geolocation.getCurrentPosition(sendLocationToServer, handleLocationError);
+            navigator.geolocation.getCurrentPosition(searchAccommodationsNearLocation, handleLocationError);
         } else {
             alert("이 브라우저에서는 위치 정보를 지원하지 않습니다.");
         }
     });
 
-    // 위치 정보를 서버로 전송하는 함수
-    function sendLocationToServer(position) {
+    function searchAccommodationsNearLocation(position) {
         const latitude = position.coords.latitude;
         const longitude = position.coords.longitude;
+        const radius = 10000; // 10km 반경으로 설정.
+        const extras = [];
+
+        // withRating 변수 선언 및 값 할당
+        const withRating = true; // 또는 사용자의 선택에 따라 동적으로 설정
+
+        // Collect selected extras
+        if ($('#search_extras_1').prop('checked')) {
+            extras.push('breakfast');
+        }
+        if ($('#search_extras_2').prop('checked')) {
+            extras.push('pet');
+        }
+        if ($('#search_extras_3').prop('checked')) {
+            extras.push('barbecue');
+        }
+        if ($('#search_extras_4').prop('checked')) {
+            extras.push('pool');
+        }
+
+        const url = `/search-accommodations-geo?latitude=${latitude}&longitude=${longitude}&radius=${radius}&extras=${extras.join('&extras=')}&withRating=${withRating}`;
 
         $.ajax({
-            url: "/save-location", // 위치 정보를 저장할 서버 측 URL
-            type: "POST",
-            contentType: "application/json",
-            data: JSON.stringify({latitude: latitude, longitude: longitude}),
-            success: function (response) {
-                alert(response); // 서버 응답 처리 (예: "위치 정보가 세션에 저장되었습니다.")
+            url: url,
+            type: "GET",
+            success: function (accommodationsWithRating) { 
+                displayGeoSearchResults(accommodationsWithRating);
             },
             error: function (error) {
-                alert("위치 정보 저장에 실패했습니다.");
+                alert("주변 숙소 검색에 실패했습니다.");
                 console.error(error);
             }
         });
     }
 
-    // 위치 정보 가져오기 실패 시 처리 함수
+// 위치 정보 가져오기 실패 시 처리 함수
     function handleLocationError(error) {
         switch (error.code) {
             case error.PERMISSION_DENIED:
@@ -385,10 +402,134 @@ $(document).ready(function () {
         }
     }
 
+// 검색 결과를 화면에 표시하는 함수
+    function displayGeoSearchResults(accommodationsWithRating) {
+        const offersGrid = $(".offers_grid");
+        offersGrid.empty();
+
+        if (accommodationsWithRating && accommodationsWithRating.length > 0) {
+            $.each(accommodationsWithRating, function (index, item) {
+                const accommodation = item.accommodation;
+                const rating = item.roundedRating;
+                const ratingClass = `rating_${rating}`;
+                let imageUrl = '';
+                if (accommodation.image1Name) {
+                    imageUrl = `/images/${accommodation.image1Name}`;
+                } else {
+                    imageUrl = `/images/default.jpg`;
+                }
+
+                const barbecueIcon = accommodation.barbecue ? `<li class="offers_icons_item" data-popper-content="바베큐 시설 안내"><i class="fa fa-fire" aria-hidden="true" title="바베큐"></i></li>` : '';
+                const breakfastIcon = accommodation.breakfast ? `<li class="offers_icons_item" data-popper-content="맛있는 조식 제공"><i class="fa fa-coffee" aria-hidden="true" title="조식"></i></li>` : '';
+                const petIcon = accommodation.pet ? `<li class="offers_icons_item" data-popper-content="반려동물 동반 가능"><i class="fa fa-paw" aria-hidden="true" title="반려동물"></i></li>` : '';
+                const poolIcon = accommodation.pool ? `<li class="offers_icons_item" data-popper-content="시원한 수영장 이용"><i class="fa fa-tint" aria-hidden="true" title="수영장"></i></li>` : '';
+
+                const listItem = `
+         <div class="offers_item ${ratingClass}">
+            <div class="row">
+               <div class="col-lg-1 temp_col"></div>
+               <div class="col-lg-3 col-1680-4">
+                  <div class="offers_image_container">
+                     <div class="offers_image_background" style="background-image:url('${imageUrl}')"></div>
+                         <div class="offer_name"><a href="/detail?id=${accommodation.accommodationId}">${accommodation.name}</a></div>
+                  </div>
+               </div>
+                       <div class="col-lg-8">
+                           <div class="offers_content">
+                               <div class="offers_price">$${accommodation.priceNight}<span>per night</span></div>
+                               <div class="rating_r rating_r_${rating} offers_rating" data-rating="${rating}">
+                                   <i></i><i></i><i></i><i></i><i></i>
+                               </div>
+                               <p class="offers_text">${accommodation.description}</p>
+                               <div class="offers_icons">
+                                   <ul class="offers_icons_list">
+                                       ${barbecueIcon}
+                                       ${breakfastIcon}
+                                       ${petIcon}
+                                       ${poolIcon}
+                                   </ul>
+                               </div>
+                               <div class="button book_button"><a href="/detail?id=${accommodation.accommodationId}">상세보기<span></span><span></span><span></span></a></div>
+                               <div class="offer_reviews">
+                                   <div class="offer_reviews_content">
+                                       <div class="offer_reviews_title">
+                                           ${getRatingText(rating)}
+                                       </div>
+                                       <div class="offer_reviews_subtitle"> 리뷰 평점: </div>
+                                   </div>
+                                   <div class="offer_reviews_rating text-center">
+                                       ${rating}
+                                   </div>
+                               </div>
+                           </div>
+                       </div>
+                   </div>
+               </div>
+           `;
+                offersGrid.append(listItem);
+            });
+
+            // 검색 결과가 그려진 후에 팝업 기능 활성화
+            initIconPopper();
+
+        } else {
+            offersGrid.html("<p>반경 10km 이내에 숙소가 없습니다!</p>");
+        }
+    }
+
+    function getRatingText(rating) {
+        if (rating >= 4) return "최고예요!";
+        if (rating === 3) return "좋아요!";
+        if (rating === 2) return "괜찮아요!";
+        if (rating === 1) return "그저 그래요!";
+        return "평가가 없어요";
+    }
+
+// 팝업 기능을 초기화하는 함수
+    function initIconPopper() {
+        const tooltipTriggers = document.querySelectorAll('.offers_icons_item[data-popper-content]');
+
+        tooltipTriggers.forEach(trigger => {
+            const tooltip = document.createElement('div');
+            tooltip.classList.add('popper-tooltip');
+            tooltip.textContent = trigger.dataset.popperContent;
+            document.body.appendChild(tooltip);
+
+            // 1.x 버전의 Popper 사용
+            const popperInstance = new Popper(trigger, tooltip, {
+                placement: 'top',
+                modifiers: {
+                    offset: {
+                        offset: '0, 8',
+                    },
+                    arrow: {
+                        element: '.popper-arrow',
+                    },
+                },
+            });
+
+            const showEvents = ['mouseenter', 'focus'];
+            const hideEvents = ['mouseleave', 'blur'];
+
+            showEvents.forEach(event => {
+                trigger.addEventListener(event, () => {
+                    tooltip.classList.add('active');
+                    popperInstance.update();
+                });
+            });
+
+            hideEvents.forEach(event => {
+                trigger.addEventListener(event, () => {
+                    tooltip.classList.remove('active');
+                });
+            });
+        });
+    }
+
     // 10. search
 
     /*
-    // 지역 검색 버튼 클릭 이벤트 리스너
+    // 검색 버튼 클릭 이벤트 리스너
      */
     $("#searchAccommodationBtn").on("click", function () {
         const location = $("#searchInput").val();

--- a/client/src/main/webapp/views/home/center.jsp
+++ b/client/src/main/webapp/views/home/center.jsp
@@ -107,8 +107,8 @@
                                 <button type="button" class="button search_button" id="searchAccommodationBtn">
                                     검색하기<span></span><span></span><span></span></button>
 
-                                <%--Geolocation 세션 저장을 위한 버튼. 어떻게 더 이쁘게 꾸밀지는 정우님 확인이 필요.--%>
-                                <button class="button search_button" id="geolocationBtn">내 위치
+                                <%--Geolocation 세션 저장을 위한 버튼.--%>
+                                <button type="button" class="button search_button" id="geolocationBtn">내 위치
                                     검색<span></span><span></span><span></span></button>
                             </form>
                         </div>


### PR DESCRIPTION
이 이슈는 추가 기능별 필터링 지원, 평점 표시, 검색 결과의 사용자 인터페이스 개선 등 지리적 위치 기반 숙소 검색 기능에 대한 개선 사항을 기재합니다. 변경 사항은 백엔드 서비스 메서드, 데이터베이스 쿼리, 프론트엔드 JavaScript, UI 업데이트등 입니다.

### 백엔드 개선 사항:
* 'AccomService'의 지리적 위치 검색 메서드 개선: `searchAccommodationsByGeoLocation` 메서드가 이제 추가 필터링을 지원하고, 선택적으로 평점을 결과에 포함할 수 있습니다. `AccomodationsWithRating`은 평점과 함께 숙소를 캡슐화하는 데 사용됩니다.
* 검색 컨트롤러 업데이트:** 이제 지리적 위치 검색 엔드포인트에서 필터링 및 평점 포함을 위한 추가 매개변수(`extras` 및 `withRating`)를 사용할 수 있습니다.

### 데이터베이스 쿼리 업데이트:
* 'accomondationmapper.xml'의 `extras` 동적 필터링: 이제 SQL 쿼리에 조건부 블록이 포함되어 선택한 엑스트라에 따라 숙소를 필터링할 수 있어 검색 맞춤 설정이 개선되었습니다.

### 프론트엔드 개선 사항:
* `custom.js`의 자바스크립트 개선 사항::**
  - 기존 지리적 위치 기능을 추가 및 평점 옵션이 포함된 요청 URL을 동적으로 작성하는 새로운 메서드인 `searchAccommodationsNearLocation`으로 대체했습니다.
  - 추가 정보 및 평점 표시 아이콘을 포함해 검색 결과를 UI에 렌더링하는 `displayGeoSearchResults`를 추가했습니다. 더 나은 사용자 경험을 위해 Popper.js를 사용한 툴팁 기능도 포함되어 있습니다.

### 위치 정보 설정 방법
크롬 기준 `개발자 도구 - application - Senors - manage` 들어가서 `Seoul`, `37.514575`, `127.0495556`, `Asia/Seoul`, `ko-KR` 값 입력하고 추가.