### PR TITLE
[feat] 최상단 바 cart 삭제, 푸터 및 카피라이트 디자인 조정

### DIFF
--- a/client/src/main/resources/static/styles/about_responsive.css
+++ b/client/src/main/resources/static/styles/about_responsive.css
@@ -142,7 +142,7 @@
 	}
 	.footer_column
 	{
-		margin-bottom: 60px;
+		margin-bottom: 10px;
 	}
 	.footer_column:last-child
 	{
@@ -150,13 +150,13 @@
 	}
 	.copyright
 	{
-		padding-top: 30px;
-		padding-bottom: 30px;
+		padding-top: 5px;
+		padding-bottom: 5px;
 	}
 	.copyright_content
 	{
 		height: auto;
-		margin-top: 15px;
+		/*margin-top: 15px;*/
 	}
 	.footer_nav_container
 	{

--- a/client/src/main/resources/static/styles/about_styles.css
+++ b/client/src/main/resources/static/styles/about_styles.css
@@ -1110,8 +1110,8 @@ section
 .footer
 {
 	width: 100%;
-	padding-top: 113px;
-	padding-bottom: 104px;
+	padding-top: 40px;
+	padding-bottom: 15px;
 	background: #31124b;
 }
 .footer_title
@@ -1128,7 +1128,7 @@ section
 
 .footer_about
 {
-	padding-top: 67px;
+	padding-top: 20px;
 }
 .footer_logo
 {
@@ -1290,11 +1290,11 @@ section
 
 .contact_info_list
 {
-	margin-top: 40px;
+	margin-top: 20px;
 }
 .contact_info_item
 {
-	margin-bottom: 22px;
+	margin-bottom: 7px;
 }
 .contact_info_icon
 {

--- a/client/src/main/resources/static/styles/blog_responsive.css
+++ b/client/src/main/resources/static/styles/blog_responsive.css
@@ -111,7 +111,7 @@
 	}
 	.footer_column
 	{
-		margin-bottom: 60px;
+		margin-bottom: 10px;
 	}
 	.footer_column:last-child
 	{

--- a/client/src/main/resources/static/styles/blog_styles.css
+++ b/client/src/main/resources/static/styles/blog_styles.css
@@ -1148,8 +1148,8 @@ section
 .footer
 {
 	width: 100%;
-	padding-top: 113px;
-	padding-bottom: 104px;
+	padding-top: 20px;
+	padding-bottom: 20px;
 	background: #31124b;
 }
 .footer_title
@@ -1166,7 +1166,7 @@ section
 
 .footer_about
 {
-	padding-top: 67px;
+	padding-top: 20px;
 }
 .footer_logo
 {
@@ -1328,11 +1328,11 @@ section
 
 .contact_info_list
 {
-	margin-top: 40px;
+	margin-top: 20px;
 }
 .contact_info_item
 {
-	margin-bottom: 22px;
+	margin-bottom: 7px;
 }
 .contact_info_icon
 {

--- a/client/src/main/resources/static/styles/contact_responsive.css
+++ b/client/src/main/resources/static/styles/contact_responsive.css
@@ -136,7 +136,7 @@
 	}
 	.footer_column
 	{
-		margin-bottom: 60px;
+		margin-bottom: 10px;
 	}
 	.footer_column:last-child
 	{

--- a/client/src/main/resources/static/styles/contact_styles.css
+++ b/client/src/main/resources/static/styles/contact_styles.css
@@ -1056,8 +1056,8 @@ section
 .footer
 {
 	width: 100%;
-	padding-top: 113px;
-	padding-bottom: 104px;
+	padding-top: 20px;
+	padding-bottom: 20px;
 	background: #31124b;
 }
 .footer_title
@@ -1074,7 +1074,7 @@ section
 
 .footer_about
 {
-	padding-top: 67px;
+	padding-top: 20px;
 }
 .footer_logo
 {
@@ -1236,11 +1236,11 @@ section
 
 .contact_info_list
 {
-	margin-top: 40px;
+	margin-top: 20px;
 }
 .contact_info_item
 {
-	margin-bottom: 22px;
+	margin-bottom: 7px;
 }
 .contact_info_icon
 {

--- a/client/src/main/resources/static/styles/main_styles.css
+++ b/client/src/main/resources/static/styles/main_styles.css
@@ -1892,8 +1892,8 @@ section
 .footer
 {
 	width: 100%;
-	padding-top: 113px;
-	padding-bottom: 104px;
+	padding-top: 20px;
+	padding-bottom: 20px;
 	background: #31124b;
 }
 .footer_title
@@ -1910,7 +1910,7 @@ section
 
 .footer_about
 {
-	padding-top: 67px;
+	padding-top: 20px;
 }
 .footer_logo
 {
@@ -2072,11 +2072,11 @@ section
 
 .contact_info_list
 {
-	margin-top: 40px;
+	margin-top: 20px;
 }
 .contact_info_item
 {
-	margin-bottom: 22px;
+	margin-bottom: 7px;
 }
 .contact_info_icon
 {

--- a/client/src/main/resources/static/styles/offers_responsive.css
+++ b/client/src/main/resources/static/styles/offers_responsive.css
@@ -338,7 +338,7 @@
 	}
 	.footer_column
 	{
-		margin-bottom: 60px;
+		margin-bottom: 10px;
 	}
 	.footer_column:last-child
 	{
@@ -346,13 +346,13 @@
 	}
 	.copyright
 	{
-		padding-top: 30px;
-		padding-bottom: 30px;
+		padding-top: 5px;
+		padding-bottom: 5px;
 	}
 	.copyright_content
 	{
 		height: auto;
-		margin-top: 15px;
+		/*margin-top: 15px;*/
 	}
 	.footer_nav_container
 	{

--- a/client/src/main/resources/static/styles/offers_styles.css
+++ b/client/src/main/resources/static/styles/offers_styles.css
@@ -1681,8 +1681,8 @@ section
 .footer
 {
 	width: 100%;
-	padding-top: 113px;
-	padding-bottom: 104px;
+	padding-top: 40px;
+	padding-bottom: 30px;
 	background: #31124b;
 }
 .footer_title
@@ -1699,7 +1699,7 @@ section
 
 .footer_about
 {
-	padding-top: 67px;
+	padding-top: 20px;
 }
 .footer_logo
 {
@@ -1861,11 +1861,11 @@ section
 
 .contact_info_list
 {
-	margin-top: 40px;
+	margin-top: 20px;
 }
 .contact_info_item
 {
-	margin-bottom: 22px;
+	margin-bottom: 7px;
 }
 .contact_info_icon
 {

--- a/client/src/main/resources/static/styles/responsive.css
+++ b/client/src/main/resources/static/styles/responsive.css
@@ -236,7 +236,7 @@
 	}
 	.footer_column
 	{
-		margin-bottom: 60px;
+		margin-bottom: 10px;
 	}
 	.footer_column:last-child
 	{

--- a/client/src/main/resources/static/styles/single_listing_responsive.css
+++ b/client/src/main/resources/static/styles/single_listing_responsive.css
@@ -326,7 +326,7 @@
 	}
 	.footer_column
 	{
-		margin-bottom: 60px;
+		margin-bottom: 10px;
 	}
 	.footer_column:last-child
 	{

--- a/client/src/main/resources/static/styles/single_listing_styles.css
+++ b/client/src/main/resources/static/styles/single_listing_styles.css
@@ -1673,8 +1673,8 @@ section
 .footer
 {
 	width: 100%;
-	padding-top: 113px;
-	padding-bottom: 104px;
+	padding-top: 30px;
+	padding-bottom: 20px;
 	background: #31124b;
 }
 .footer_title
@@ -1853,11 +1853,11 @@ section
 
 .contact_info_list
 {
-	margin-top: 40px;
+	margin-top: 20px;
 }
 .contact_info_item
 {
-	margin-bottom: 22px;
+	margin-bottom: 7px;
 }
 .contact_info_icon
 {

--- a/client/src/main/webapp/views/about/footer.jsp
+++ b/client/src/main/webapp/views/about/footer.jsp
@@ -17,7 +17,7 @@
         <div class="row">
 
             <!-- 회사 정보 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
                     <div class="footer_content footer_about">
                         <div class="logo_container footer_logo">
@@ -29,67 +29,9 @@
                 </div>
             </div>
 
-            <!-- 기존 템플릿 내용 삭제 후 정렬을 위한 빈 칸으로 활용 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <%--<div class="footer_title">blog posts</div>
-                    <div class="footer_content footer_blog">
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_1.jpg" alt="https://unsplash.com/@avidenov"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_2.jpg" alt="https://unsplash.com/@deannaritchie"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">New destinations for you</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_3.jpg" alt="https://unsplash.com/@bergeryap87"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                    </div>--%>
-                </div>
-            </div>
-
-
-            <!-- 태그 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <div class="footer_title">태그</div>
-                    <div class="footer_content footer_tags">
-                        <ul class="tags_list clearfix">
-                            <li class="tag_item"><a href="#">바캉스</a></li>
-                            <li class="tag_item"><a href="#">호캉스</a></li>
-                            <li class="tag_item"><a href="#">페스티벌</a></li>
-                            <li class="tag_item"><a href="#">파티</a></li>
-                            <li class="tag_item"><a href="#">프라이빗</a></li>
-                            <li class="tag_item"><a href="#">마운틴뷰</a></li>
-                            <li class="tag_item"><a href="#">시티뷰</a></li>
-                            <li class="tag_item"><a href="#">오션뷰</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-
             <!-- 연락처 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
-                    <div class="footer_title">연락처</div>
                     <div class="footer_content footer_contact">
                         <ul class="contact_info_list">
                             <li class="contact_info_item d-flex flex-row">

--- a/client/src/main/webapp/views/about/headers.jsp
+++ b/client/src/main/webapp/views/about/headers.jsp
@@ -41,9 +41,6 @@
                                     <a href="<c:url value="/mypage?name=${sessionScope.user.name}"/> ">${sessionScope.user.name}</a>
                                 </div>
                                 <div class="user_box_login user_box_link">
-                                    <a href="<c:url value="/cart?name=${sessionScope.user.name}"/> ">Cart</a>
-                                </div>
-                                <div class="user_box_login user_box_link">
                                     <a href="<c:url value="/auth/logout"/> ">logout</a>
                                 </div>
                                 <div class="user_box_login theme-switch">

--- a/client/src/main/webapp/views/contacts/footer.jsp
+++ b/client/src/main/webapp/views/contacts/footer.jsp
@@ -9,7 +9,7 @@
         <div class="row">
 
             <!-- 회사 정보 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
                     <div class="footer_content footer_about">
                         <div class="logo_container footer_logo">
@@ -21,67 +21,10 @@
                 </div>
             </div>
 
-            <!-- 기존 템플릿 내용 삭제 후 정렬을 위한 빈 칸으로 활용 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <%--<div class="footer_title">blog posts</div>
-                    <div class="footer_content footer_blog">
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_1.jpg" alt="https://unsplash.com/@avidenov"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_2.jpg" alt="https://unsplash.com/@deannaritchie"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">New destinations for you</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_3.jpg" alt="https://unsplash.com/@bergeryap87"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                    </div>--%>
-                </div>
-            </div>
-
-
-            <!-- 태그 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <div class="footer_title">태그</div>
-                    <div class="footer_content footer_tags">
-                        <ul class="tags_list clearfix">
-                            <li class="tag_item"><a href="#">바캉스</a></li>
-                            <li class="tag_item"><a href="#">호캉스</a></li>
-                            <li class="tag_item"><a href="#">페스티벌</a></li>
-                            <li class="tag_item"><a href="#">파티</a></li>
-                            <li class="tag_item"><a href="#">프라이빗</a></li>
-                            <li class="tag_item"><a href="#">마운틴뷰</a></li>
-                            <li class="tag_item"><a href="#">시티뷰</a></li>
-                            <li class="tag_item"><a href="#">오션뷰</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
 
             <!-- 연락처 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
-                    <div class="footer_title">연락처</div>
                     <div class="footer_content footer_contact">
                         <ul class="contact_info_list">
                             <li class="contact_info_item d-flex flex-row">

--- a/client/src/main/webapp/views/contacts/headers.jsp
+++ b/client/src/main/webapp/views/contacts/headers.jsp
@@ -41,9 +41,6 @@
                                     <a href="<c:url value="/mypage?name=${sessionScope.user.name}"/> ">${sessionScope.user.name}</a>
                                 </div>
                                 <div class="user_box_login user_box_link">
-                                    <a href="<c:url value="/cart?name=${sessionScope.user.name}"/> ">Cart</a>
-                                </div>
-                                <div class="user_box_login user_box_link">
                                     <a href="<c:url value="/auth/logout"/> ">logout</a>
                                 </div>
                                 <div class="user_box_login theme-switch">

--- a/client/src/main/webapp/views/details/footer.jsp
+++ b/client/src/main/webapp/views/details/footer.jsp
@@ -10,7 +10,7 @@
         <div class="row">
 
             <!-- 회사 정보 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
                     <div class="footer_content footer_about">
                         <div class="logo_container footer_logo">
@@ -22,67 +22,9 @@
                 </div>
             </div>
 
-            <!-- 기존 템플릿 내용 삭제 후 정렬을 위한 빈 칸으로 활용 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <%--<div class="footer_title">blog posts</div>
-                    <div class="footer_content footer_blog">
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_1.jpg" alt="https://unsplash.com/@avidenov"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_2.jpg" alt="https://unsplash.com/@deannaritchie"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">New destinations for you</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_3.jpg" alt="https://unsplash.com/@bergeryap87"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                    </div>--%>
-                </div>
-            </div>
-
-
-            <!-- 태그 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <div class="footer_title">태그</div>
-                    <div class="footer_content footer_tags">
-                        <ul class="tags_list clearfix">
-                            <li class="tag_item"><a href="#">바캉스</a></li>
-                            <li class="tag_item"><a href="#">호캉스</a></li>
-                            <li class="tag_item"><a href="#">페스티벌</a></li>
-                            <li class="tag_item"><a href="#">파티</a></li>
-                            <li class="tag_item"><a href="#">프라이빗</a></li>
-                            <li class="tag_item"><a href="#">마운틴뷰</a></li>
-                            <li class="tag_item"><a href="#">시티뷰</a></li>
-                            <li class="tag_item"><a href="#">오션뷰</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-
             <!-- 연락처 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
-                    <div class="footer_title">연락처</div>
                     <div class="footer_content footer_contact">
                         <ul class="contact_info_list">
                             <li class="contact_info_item d-flex flex-row">

--- a/client/src/main/webapp/views/details/headers.jsp
+++ b/client/src/main/webapp/views/details/headers.jsp
@@ -43,9 +43,6 @@
                                         <a href="<c:url value="/mypage?name=${sessionScope.user.name}"/> ">${sessionScope.user.name}</a>
                                     </div>
                                     <div class="user_box_login user_box_link">
-                                        <a href="<c:url value="/cart?name=${sessionScope.user.name}"/> ">Cart</a>
-                                    </div>
-                                    <div class="user_box_login user_box_link">
                                         <a href="<c:url value="/auth/logout"/> ">logout</a>
                                     </div>
                                     <div class="user_box_login theme-switch">

--- a/client/src/main/webapp/views/home/footer.jsp
+++ b/client/src/main/webapp/views/home/footer.jsp
@@ -8,7 +8,7 @@
         <div class="row">
 
             <!-- 회사 정보 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
                     <div class="footer_content footer_about">
                         <div class="logo_container footer_logo">
@@ -20,67 +20,9 @@
                 </div>
             </div>
 
-            <!-- 기존 템플릿 내용 삭제 후 정렬을 위한 빈 칸으로 활용 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <%--<div class="footer_title">blog posts</div>
-                    <div class="footer_content footer_blog">
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_1.jpg" alt="https://unsplash.com/@avidenov"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_2.jpg" alt="https://unsplash.com/@deannaritchie"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">New destinations for you</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_3.jpg" alt="https://unsplash.com/@bergeryap87"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                    </div>--%>
-                </div>
-            </div>
-
-
-            <!-- 태그 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <div class="footer_title">태그</div>
-                    <div class="footer_content footer_tags">
-                        <ul class="tags_list clearfix">
-                            <li class="tag_item"><a href="#">바캉스</a></li>
-                            <li class="tag_item"><a href="#">호캉스</a></li>
-                            <li class="tag_item"><a href="#">페스티벌</a></li>
-                            <li class="tag_item"><a href="#">파티</a></li>
-                            <li class="tag_item"><a href="#">프라이빗</a></li>
-                            <li class="tag_item"><a href="#">마운틴뷰</a></li>
-                            <li class="tag_item"><a href="#">시티뷰</a></li>
-                            <li class="tag_item"><a href="#">오션뷰</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-
             <!-- 연락처 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
-                    <div class="footer_title">연락처</div>
                     <div class="footer_content footer_contact">
                         <ul class="contact_info_list">
                             <li class="contact_info_item d-flex flex-row">

--- a/client/src/main/webapp/views/home/headers.jsp
+++ b/client/src/main/webapp/views/home/headers.jsp
@@ -40,9 +40,6 @@
                                     <a href="<c:url value="/mypage?name=${sessionScope.user.name}"/> ">${sessionScope.user.name}</a>
                                 </div>
                                 <div class="user_box_login user_box_link">
-                                    <a href="<c:url value="/cart?name=${sessionScope.user.name}"/> ">Cart</a>
-                                </div>
-                                <div class="user_box_login user_box_link">
                                     <a href="<c:url value="/auth/logout"/> ">logout</a>
                                 </div>
                                 <div class="user_box_login theme-switch">

--- a/client/src/main/webapp/views/mypage/center.jsp
+++ b/client/src/main/webapp/views/mypage/center.jsp
@@ -4,6 +4,82 @@
 
 <head>
     <link rel="stylesheet" type="text/css" href="styles/darkmode.css">
+    <style>
+        /* --- Basic Layout --- */
+        .listing {
+            padding-top: 50px;
+            padding-bottom: 50px;
+            background-color: #f8f9fa; /* Light background */
+        }
+
+        .container {
+            max-width: 960px;
+            margin: 0 auto;
+            padding: 0 15px;
+        }
+
+        .single_listing {
+            background-color: #fff;
+            border-radius: 8px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+            padding: 30px;
+        }
+
+        .hotel_info {
+            margin-bottom: 20px;
+            text-align: center;
+        }
+
+        .hotel_title_container {
+            margin-bottom: 20px;
+        }
+
+        .hotel_title {
+            font-size: 2.5rem;
+            color: #333;
+            margin-bottom: 10px;
+        }
+
+        .hotel_image img {
+            width: 100%;
+            border-radius: 8px;
+            margin-bottom: 20px;
+        }
+
+        /* --- User Information Styling --- */
+        .hotel_info_text {
+            padding: 20px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            background-color: #fff;
+        }
+
+        .user-info-item {
+            display: flex;
+            align-items: center;
+            margin-bottom: 15px;
+        }
+
+        .user-info-label {
+            font-weight: bold;
+            color: #555;
+            width: 120px; /* Adjust width as needed */
+            margin-right: 15px;
+        }
+
+        .user-info-value {
+            color: #333;
+        }
+
+        .error-message {
+            color: red;
+            margin-bottom: 15px;
+        }
+
+        .no-update-message {
+            color: #777;
+        }
+    </style>
 </head>
 
 <div class="menu trans_500">
@@ -19,515 +95,76 @@
     </div>
 </div>
 
-    <!-- Home -->
-
-    <div class="home">
-        <div class="home_background parallax-window" data-parallax="scroll"
-             data-image-src="static/images/single_background.jpg"></div>
-        <div class="home_content">
-            <div class="home_title">My Page</div>
-        </div>
+<div class="home">
+    <div class="home_background parallax-window" data-parallax="scroll"
+         data-image-src="/images/single_background.jpg"></div>
+    <div class="home_content">
+        <div class="home_title">My Page</div>
     </div>
-    <!-- Offers -->
+</div>
+<div class="listing">
 
-    <div class="listing">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="single_listing">
 
-        <!-- Search -->
+                    <div class="hotel_info">
 
-        <div class="search">
-            <div class="search_inner">
-
-                <!-- Search Contents -->
-
-                <div class="container fill_height no-padding">
-                    <div class="row fill_height no-margin">
-                        <div class="col fill_height no-padding">
-
-                            <!-- Search Tabs -->
-
-                            <div class="search_tabs_container">
-                                <div class="search_tabs d-flex flex-lg-row flex-column align-items-lg-center align-items-start justify-content-lg-between justify-content-start">
-                                    <div class="search_tab active d-flex flex-row align-items-center justify-content-lg-center justify-content-start">
-                                        <img src="images/suitcase.png" alt=""><span>hotels</span></div>
-                                    <div class="search_tab d-flex flex-row align-items-center justify-content-lg-center justify-content-start">
-                                        <img src="images/bus.png" alt="">car rentals
-                                    </div>
-                                    <div class="search_tab d-flex flex-row align-items-center justify-content-lg-center justify-content-start">
-                                        <img src="images/departure.png" alt="">flights
-                                    </div>
-                                    <div class="search_tab d-flex flex-row align-items-center justify-content-lg-center justify-content-start">
-                                        <img src="images/island.png" alt="">trips
-                                    </div>
-                                    <div class="search_tab d-flex flex-row align-items-center justify-content-lg-center justify-content-start">
-                                        <img src="images/cruise.png" alt="">cruises
-                                    </div>
-                                    <div class="search_tab d-flex flex-row align-items-center justify-content-lg-center justify-content-start">
-                                        <img src="images/diving.png" alt="">activities
-                                    </div>
-                                </div>
+                        <div class="hotel_title_container d-flex flex-lg-row flex-column">
+                            <div class="hotel_title_content">
+                                <h1 class="hotel_title">개인 정보</h1>
                             </div>
+                        </div>
 
-                            <!-- Search Panel -->
-
-                            <div class="search_panel active">
-                                <form action="#" id="search_form_1"
-                                      class="search_panel_content d-flex flex-lg-row flex-column align-items-lg-center align-items-start justify-content-lg-between justify-content-start">
-                                    <div class="search_item">
-                                        <div>destination</div>
-                                        <input type="text" class="destination search_input" required="required">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>check in</div>
-                                        <input type="text" class="check_in search_input" placeholder="YYYY-MM-DD">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>check out</div>
-                                        <input type="text" class="check_out search_input" placeholder="YYYY-MM-DD">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>adults</div>
-                                        <select name="adults" id="adults_1" class="dropdown_item_select search_input">
-                                            <option>01</option>
-                                            <option>02</option>
-                                            <option>03</option>
-                                        </select>
-                                    </div>
-                                    <div class="search_item">
-                                        <div>children</div>
-                                        <select name="children" id="children_1"
-                                                class="dropdown_item_select search_input">
-                                            <option>0</option>
-                                            <option>02</option>
-                                            <option>03</option>
-                                        </select>
-                                    </div>
-                                    <div class="extras">
-                                        <ul class="search_extras clearfix">
-                                            <li class="search_extras_item">
-                                                <div class="clearfix">
-                                                    <input type="checkbox" id="search_extras_1"
-                                                           class="search_extras_cb">
-                                                    <label for="search_extras_1">Pet Friendly</label>
-                                                </div>
-                                            </li>
-                                            <li class="search_extras_item">
-                                                <div class="clearfix">
-                                                    <input type="checkbox" id="search_extras_2"
-                                                           class="search_extras_cb">
-                                                    <label for="search_extras_2">Car Parking</label>
-                                                </div>
-                                            </li>
-                                            <li class="search_extras_item">
-                                                <div class="clearfix">
-                                                    <input type="checkbox" id="search_extras_3"
-                                                           class="search_extras_cb">
-                                                    <label for="search_extras_3">Wireless Internet</label>
-                                                </div>
-                                            </li>
-                                            <li class="search_extras_item">
-                                                <div class="clearfix">
-                                                    <input type="checkbox" id="search_extras_4"
-                                                           class="search_extras_cb">
-                                                    <label for="search_extras_4">Reservations</label>
-                                                </div>
-                                            </li>
-                                            <li class="search_extras_item">
-                                                <div class="clearfix">
-                                                    <input type="checkbox" id="search_extras_5"
-                                                           class="search_extras_cb">
-                                                    <label for="search_extras_5">Private Parking</label>
-                                                </div>
-                                            </li>
-                                            <li class="search_extras_item">
-                                                <div class="clearfix">
-                                                    <input type="checkbox" id="search_extras_6"
-                                                           class="search_extras_cb">
-                                                    <label for="search_extras_6">Smoking Area</label>
-                                                </div>
-                                            </li>
-                                            <li class="search_extras_item">
-                                                <div class="clearfix">
-                                                    <input type="checkbox" id="search_extras_7"
-                                                           class="search_extras_cb">
-                                                    <label for="search_extras_7">Wheelchair Accessible</label>
-                                                </div>
-                                            </li>
-                                            <li class="search_extras_item">
-                                                <div class="clearfix">
-                                                    <input type="checkbox" id="search_extras_8"
-                                                           class="search_extras_cb">
-                                                    <label for="search_extras_8">Pool</label>
-                                                </div>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                    <div class="more_options">
-                                        <div class="more_options_trigger">
-                                            <a href="#">load more options</a>
-                                        </div>
-                                        <ul class="more_options_list clearfix">
-                                            <li class="more_options_item">
-                                                <div class="clearfix">
-                                                    <input type="checkbox" id="more_options_1" class="search_extras_cb">
-                                                    <label for="more_options_1">Pet Friendly</label>
-                                                </div>
-                                            </li>
-                                            <li class="more_options_item">
-                                                <div class="clearfix">
-                                                    <input type="checkbox" id="more_options_2" class="search_extras_cb">
-                                                    <label for="more_options_2">Car Parking</label>
-                                                </div>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                    <button class="button search_button">search<span></span><span></span><span></span>
-                                    </button>
-                                </form>
-                            </div>
-
-                            <!-- Search Panel -->
-
-                            <div class="search_panel">
-                                <form action="#" id="search_form_2"
-                                      class="search_panel_content d-flex flex-lg-row flex-column align-items-lg-center align-items-start justify-content-lg-between justify-content-start">
-                                    <div class="search_item">
-                                        <div>destination</div>
-                                        <input type="text" class="destination search_input" required="required">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>check in</div>
-                                        <input type="text" class="check_in search_input" placeholder="YYYY-MM-DD">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>check out</div>
-                                        <input type="text" class="check_out search_input" placeholder="YYYY-MM-DD">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>adults</div>
-                                        <select name="adults" id="adults_2" class="dropdown_item_select search_input">
-                                            <option>01</option>
-                                            <option>02</option>
-                                            <option>03</option>
-                                        </select>
-                                    </div>
-                                    <div class="search_item">
-                                        <div>children</div>
-                                        <select name="children" id="children_2"
-                                                class="dropdown_item_select search_input">
-                                            <option>0</option>
-                                            <option>02</option>
-                                            <option>03</option>
-                                        </select>
-                                    </div>
-                                    <button class="button search_button">search<span></span><span></span><span></span>
-                                    </button>
-                                </form>
-                            </div>
-
-                            <!-- Search Panel -->
-
-                            <div class="search_panel">
-                                <form action="#" id="search_form_3"
-                                      class="search_panel_content d-flex flex-lg-row flex-column align-items-lg-center align-items-start justify-content-lg-between justify-content-start">
-                                    <div class="search_item">
-                                        <div>destination</div>
-                                        <input type="text" class="destination search_input" required="required">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>check in</div>
-                                        <input type="text" class="check_in search_input" placeholder="YYYY-MM-DD">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>check out</div>
-                                        <input type="text" class="check_out search_input" placeholder="YYYY-MM-DD">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>adults</div>
-                                        <select name="adults" id="adults_3" class="dropdown_item_select search_input">
-                                            <option>01</option>
-                                            <option>02</option>
-                                            <option>03</option>
-                                        </select>
-                                    </div>
-                                    <div class="search_item">
-                                        <div>children</div>
-                                        <select name="children" id="children_3"
-                                                class="dropdown_item_select search_input">
-                                            <option>0</option>
-                                            <option>02</option>
-                                            <option>03</option>
-                                        </select>
-                                    </div>
-                                    <button class="button search_button">search<span></span><span></span><span></span>
-                                    </button>
-                                </form>
-                            </div>
-
-                            <!-- Search Panel -->
-
-                            <div class="search_panel">
-                                <form action="#" id="search_form_4"
-                                      class="search_panel_content d-flex flex-lg-row flex-column align-items-lg-center align-items-start justify-content-lg-between justify-content-start">
-                                    <div class="search_item">
-                                        <div>destination</div>
-                                        <input type="text" class="destination search_input" required="required">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>check in</div>
-                                        <input type="text" class="check_in search_input" placeholder="YYYY-MM-DD">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>check out</div>
-                                        <input type="text" class="check_out search_input" placeholder="YYYY-MM-DD">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>adults</div>
-                                        <select name="adults" id="adults_4" class="dropdown_item_select search_input">
-                                            <option>01</option>
-                                            <option>02</option>
-                                            <option>03</option>
-                                        </select>
-                                    </div>
-                                    <div class="search_item">
-                                        <div>children</div>
-                                        <select name="children" id="children_4"
-                                                class="dropdown_item_select search_input">
-                                            <option>0</option>
-                                            <option>02</option>
-                                            <option>03</option>
-                                        </select>
-                                    </div>
-                                    <button class="button search_button">search<span></span><span></span><span></span>
-                                    </button>
-                                </form>
-                            </div>
-
-                            <!-- Search Panel -->
-
-                            <div class="search_panel">
-                                <form action="#" id="search_form_5"
-                                      class="search_panel_content d-flex flex-lg-row flex-column align-items-lg-center align-items-start justify-content-lg-between justify-content-start">
-                                    <div class="search_item">
-                                        <div>destination</div>
-                                        <input type="text" class="destination search_input" required="required">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>check in</div>
-                                        <input type="text" class="check_in search_input" placeholder="YYYY-MM-DD">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>check out</div>
-                                        <input type="text" class="check_out search_input" placeholder="YYYY-MM-DD">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>adults</div>
-                                        <select name="adults" id="adults_5" class="dropdown_item_select search_input">
-                                            <option>01</option>
-                                            <option>02</option>
-                                            <option>03</option>
-                                        </select>
-                                    </div>
-                                    <div class="search_item">
-                                        <div>children</div>
-                                        <select name="children" id="children_5"
-                                                class="dropdown_item_select search_input">
-                                            <option>0</option>
-                                            <option>02</option>
-                                            <option>03</option>
-                                        </select>
-                                    </div>
-                                    <button class="button search_button">search<span></span><span></span><span></span>
-                                    </button>
-                                </form>
-                            </div>
-
-                            <!-- Search Panel -->
-
-                            <div class="search_panel">
-                                <form action="#" id="search_form_6"
-                                      class="search_panel_content d-flex flex-lg-row flex-column align-items-lg-center align-items-start justify-content-lg-between justify-content-start">
-                                    <div class="search_item">
-                                        <div>destination</div>
-                                        <input type="text" class="destination search_input" required="required">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>check in</div>
-                                        <input type="text" class="check_in search_input" placeholder="YYYY-MM-DD">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>check out</div>
-                                        <input type="text" class="check_out search_input" placeholder="YYYY-MM-DD">
-                                    </div>
-                                    <div class="search_item">
-                                        <div>adults</div>
-                                        <select name="adults" id="adults_6" class="dropdown_item_select search_input">
-                                            <option>01</option>
-                                            <option>02</option>
-                                            <option>03</option>
-                                        </select>
-                                    </div>
-                                    <div class="search_item">
-                                        <div>children</div>
-                                        <select name="children" id="children_6"
-                                                class="dropdown_item_select search_input">
-                                            <option>0</option>
-                                            <option>02</option>
-                                            <option>03</option>
-                                        </select>
-                                    </div>
-                                    <button class="button search_button">search<span></span><span></span><span></span>
-                                    </button>
-                                </form>
-                            </div>
+                        <div class="hotel_image">
+                            <img src="/images/user_profile.jpg" alt="User Profile">
                         </div>
                     </div>
                 </div>
-            </div>
-        </div>
 
-        <!-- Single Listing -->
+                <div class="hotel_info_text">
+                    <c:if test="${errorMessage != null}">
+                        <p class="error-message">${errorMessage}</p>
+                    </c:if>
 
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-12">
-                    <div class="single_listing">
-
-                        <!-- Hotel Info -->
-
-                        <div class="hotel_info">
-
-                            <!-- Title -->
-                            <div class="hotel_title_container d-flex flex-lg-row flex-column">
-                                <div class="hotel_title_content">
-                                    <h1 class="hotel_title">임시 페이지 입니다</h1>
-                                    <div class="rating_r rating_r_4 hotel_rating">
-                                        <i></i>
-                                        <i></i>
-                                        <i></i>
-                                        <i></i>
-                                        <i></i>
-                                    </div>
-                                    <div class="hotel_location">345 677 Gran Via Street, no 34, Madrid, Spain</div>
-                                </div>
-                                <div class="hotel_title_button ml-lg-auto text-lg-right">
-                                    <div class="button book_button trans_200"><a
-                                            href="#">book<span></span><span></span><span></span></a></div>
-                                    <div class="hotel_map_link_container">
-                                        <div class="hotel_map_link">See Location on Map</div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Listing Image -->
-
-                            <div class="hotel_image">
-                                <img src="images/listing_hotel.jpg" alt="">
-                            </div>
+                    <c:if test="${not empty user}">  <%-- user 객체 존재 여부로 분기 --%>
+                        <div class="user-info-item">
+                            <span class="user-info-label">이메일:</span>
+                            <span class="user-info-value">${user.email}</span>
                         </div>
-                    </div>
-
-<%--                    <!-- Hotel Gallery -->--%>
-
-<%--                    <div class="hotel_gallery">--%>
-<%--                        <div class="hotel_slider_container">--%>
-<%--                            <div class="owl-carousel owl-theme hotel_slider">--%>
-
-<%--                                <!-- Hotel Gallery Slider Item -->--%>
-<%--                                <div class="owl-item">--%>
-<%--                                    <a class="colorbox cboxElement" href="images/listing_1.jpg">--%>
-<%--                                        <img src="images/listing_thumb_1.jpg" alt="https://unsplash.com/@jbriscoe">--%>
-<%--                                    </a>--%>
-<%--                                </div>--%>
-
-<%--                                <!-- Hotel Gallery Slider Item -->--%>
-<%--                                <div class="owl-item">--%>
-<%--                                    <a class="colorbox cboxElement" href="images/listing_2.jpg">--%>
-<%--                                        <img src="images/listing_thumb_2.jpg" alt="https://unsplash.com/@grovemade">--%>
-<%--                                    </a>--%>
-<%--                                </div>--%>
-
-<%--                                <!-- Hotel Gallery Slider Item -->--%>
-<%--                                <div class="owl-item">--%>
-<%--                                    <a class="colorbox cboxElement" href="images/listing_3.jpg">--%>
-<%--                                        <img src="images/listing_thumb_3.jpg"--%>
-<%--                                             alt="https://unsplash.com/@fransaraco">--%>
-<%--                                    </a>--%>
-<%--                                </div>--%>
-
-<%--                                <!-- Hotel Gallery Slider Item -->--%>
-<%--                                <div class="owl-item">--%>
-<%--                                    <a class="colorbox cboxElement" href="images/listing_4.jpg">--%>
-<%--                                        <img src="images/listing_thumb_4.jpg" alt="https://unsplash.com/@workweek">--%>
-<%--                                    </a>--%>
-<%--                                </div>--%>
-
-<%--                                <!-- Hotel Gallery Slider Item -->--%>
-<%--                                <div class="owl-item">--%>
-<%--                                    <a class="colorbox cboxElement" href="images/listing_5.jpg">--%>
-<%--                                        <img src="images/listing_thumb_5.jpg" alt="https://unsplash.com/@workweek">--%>
-<%--                                    </a>--%>
-<%--                                </div>--%>
-
-<%--                                <!-- Hotel Gallery Slider Item -->--%>
-<%--                                <div class="owl-item">--%>
-<%--                                    <a class="colorbox cboxElement" href="images/listing_6.jpg">--%>
-<%--                                        <img src="images/listing_thumb_6.jpg" alt="https://unsplash.com/@avidenov">--%>
-<%--                                    </a>--%>
-<%--                                </div>--%>
-
-<%--                                <!-- Hotel Gallery Slider Item -->--%>
-<%--                                <div class="owl-item">--%>
-<%--                                    <a class="colorbox cboxElement" href="images/listing_7.jpg">--%>
-<%--                                        <img src="images/listing_thumb_7.jpg"--%>
-<%--                                             alt="https://unsplash.com/@pietruszka">--%>
-<%--                                    </a>--%>
-<%--                                </div>--%>
-
-<%--                                <!-- Hotel Gallery Slider Item -->--%>
-<%--                                <div class="owl-item">--%>
-<%--                                    <a class="colorbox cboxElement" href="images/listing_8.jpg">--%>
-<%--                                        <img src="images/listing_thumb_8.jpg" alt="https://unsplash.com/@rktkn">--%>
-<%--                                    </a>--%>
-<%--                                </div>--%>
-
-<%--                                <!-- Hotel Gallery Slider Item -->--%>
-<%--                                <div class="owl-item">--%>
-<%--                                    <a class="colorbox cboxElement" href="images/listing_9.jpg">--%>
-<%--                                        <img src="images/listing_thumb_9.jpg" alt="https://unsplash.com/@mindaugas">--%>
-<%--                                    </a>--%>
-<%--                                </div>--%>
-<%--                            </div>--%>
-<%--                        </div>--%>
-<%--                    </div>--%>
-
-                    <!-- Hotel Info Text -->
-                    <div class="hotel_info_text">
-                        <c:if test="${errorMessage != null}">
-                            <p style="color: red;">${errorMessage}</p>
-                        </c:if>
-
-                        <c:if test="${not empty user}">  <%-- user 객체 존재 여부로 분기 --%>
-                            <p>이메일: ${user.email}</p>
-                            <p>이름: ${user.name}</p>
-                            <p>전화번호: ${user.phone}</p>
-                            <p>가입일: ${user.createDay}</p>
-                            <p>정보 수정일:
-                                <c:choose>
-                                    <c:when test="${user.updateDay == null}">
-                                        수정 기록 없음
-                                    </c:when>
-                                    <c:otherwise>
-                                        ${user.updateDay}
-                                    </c:otherwise>
-                                </c:choose>
-                            </p>
-                        </c:if>
-                    </div>
-
+                        <div class="user-info-item">
+                            <span class="user-info-label">이름:</span>
+                            <span class="user-info-value">${user.name}</span>
+                        </div>
+                        <div class="user-info-item">
+                            <span class="user-info-label">전화번호:</span>
+                            <span class="user-info-value">${user.phone}</span>
+                        </div>
+                        <div class="user-info-item">
+                            <span class="user-info-label">가입일:</span>
+                            <span class="user-info-value">${user.createDay}</span>
+                        </div>
+                        <div class="user-info-item">
+                            <span class="user-info-label">정보 수정일:</span>
+                            <span class="user-info-value">
+                                    <c:choose>
+                                        <c:when test="${user.updateDay == null}">
+                                            <span class="no-update-message">수정 기록 없음</span>
+                                        </c:when>
+                                        <c:otherwise>
+                                            ${user.updateDay}
+                                        </c:otherwise>
+                                    </c:choose>
+                                </span>
+                        </div>
+                    </c:if>
                 </div>
+
             </div>
         </div>
     </div>
+</div>
 
 <script src="js/jquery-3.2.1.min.js"></script>
 <script src="styles/bootstrap4/popper.js"></script>

--- a/client/src/main/webapp/views/mypage/footer.jsp
+++ b/client/src/main/webapp/views/mypage/footer.jsp
@@ -3,9 +3,6 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
 
-
-<body>
-
 <!-- 푸터 -->
 
 <footer class="footer">
@@ -13,7 +10,7 @@
     <div class="row">
 
       <!-- 회사 정보 -->
-      <div class="col-lg-3 footer_column">
+      <div class="col-lg-12 footer_column">
         <div class="footer_col">
           <div class="footer_content footer_about">
             <div class="logo_container footer_logo">
@@ -25,66 +22,9 @@
         </div>
       </div>
 
-      <!-- Footer Column -->
-      <div class="col-lg-3 footer_column">
-        <div class="footer_col">
-          <div class="footer_title">blog posts</div>
-          <div class="footer_content footer_blog">
-
-            <!-- Footer blog item -->
-            <div class="footer_blog_item clearfix">
-              <div class="footer_blog_image"><img src="images/footer_blog_1.jpg" alt="https://unsplash.com/@avidenov"></div>
-              <div class="footer_blog_content">
-                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                <div class="footer_blog_date">Nov 29, 2017</div>
-              </div>
-            </div>
-
-            <!-- Footer blog item -->
-            <div class="footer_blog_item clearfix">
-              <div class="footer_blog_image"><img src="images/footer_blog_2.jpg" alt="https://unsplash.com/@deannaritchie"></div>
-              <div class="footer_blog_content">
-                <div class="footer_blog_title"><a href="blog.html">New destinations for you</a></div>
-                <div class="footer_blog_date">Nov 29, 2017</div>
-              </div>
-            </div>
-
-            <!-- Footer blog item -->
-            <div class="footer_blog_item clearfix">
-              <div class="footer_blog_image"><img src="images/footer_blog_3.jpg" alt="https://unsplash.com/@bergeryap87"></div>
-              <div class="footer_blog_content">
-                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                <div class="footer_blog_date">Nov 29, 2017</div>
-              </div>
-            </div>
-
-          </div>
-        </div>
-      </div>
-
-      <!-- 태그 -->
-      <div class="col-lg-3 footer_column">
-        <div class="footer_col">
-          <div class="footer_title">태그</div>
-          <div class="footer_content footer_tags">
-            <ul class="tags_list clearfix">
-              <li class="tag_item"><a href="#">바캉스</a></li>
-              <li class="tag_item"><a href="#">호캉스</a></li>
-              <li class="tag_item"><a href="#">페스티벌</a></li>
-              <li class="tag_item"><a href="#">파티</a></li>
-              <li class="tag_item"><a href="#">프라이빗</a></li>
-              <li class="tag_item"><a href="#">마운틴뷰</a></li>
-              <li class="tag_item"><a href="#">시티뷰</a></li>
-              <li class="tag_item"><a href="#">오션뷰</a></li>
-            </ul>
-          </div>
-        </div>
-      </div>
-
       <!-- 연락처 -->
-      <div class="col-lg-3 footer_column">
+      <div class="col-lg-12 footer_column">
         <div class="footer_col">
-          <div class="footer_title">연락처</div>
           <div class="footer_content footer_contact">
             <ul class="contact_info_list">
               <li class="contact_info_item d-flex flex-row">
@@ -112,21 +52,6 @@
   </div>
 </footer>
 
-<!-- Copyright -->
-
-<div class="copyright">
-  <div class="container">
-    <div class="row">
-      <div class="col-lg-3 order-lg-1 order-2  ">
-        <div class="copyright_content d-flex flex-row align-items-center">
-          <div><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
-            Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved </a>
-            <!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. --></div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
 
 <script src="js/jquery-3.2.1.min.js"></script>
 <script src="styles/bootstrap4/popper.js"></script>
@@ -135,6 +60,3 @@
 <script src="plugins/easing/easing.js"></script>
 <script src="js/custom.js"></script>
 
-</body>
-
-</html>

--- a/client/src/main/webapp/views/mypage/headers.jsp
+++ b/client/src/main/webapp/views/mypage/headers.jsp
@@ -41,9 +41,6 @@
                                     <a href="<c:url value="/mypage?name=${sessionScope.user.name}"/> ">${sessionScope.user.name}</a>
                                 </div>
                                 <div class="user_box_login user_box_link">
-                                    <a href="<c:url value="/cart?name=${sessionScope.user.name}"/> ">Cart</a>
-                                </div>
-                                <div class="user_box_login user_box_link">
                                     <a href="<c:url value="/auth/logout"/> ">logout</a>
                                 </div>
                                 <div class="user_box_login theme-switch">

--- a/client/src/main/webapp/views/offers.jsp
+++ b/client/src/main/webapp/views/offers.jsp
@@ -63,9 +63,6 @@
                     <a href="<c:url value="/mypage?name=${sessionScope.user.name}"/> ">${sessionScope.user.name}</a>
                   </div>
                   <div class="user_box_login user_box_link">
-                    <a href="<c:url value="/cart?name=${sessionScope.user.name}"/> ">Cart</a>
-                  </div>
-                  <div class="user_box_login user_box_link">
                     <a href="<c:url value="/auth/logout"/> ">logout</a></div>
                 </div>
               </c:otherwise>

--- a/client/src/main/webapp/views/payments/footer.jsp
+++ b/client/src/main/webapp/views/payments/footer.jsp
@@ -10,7 +10,7 @@
         <div class="row">
 
             <!-- 회사 정보 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
                     <div class="footer_content footer_about">
                         <div class="logo_container footer_logo">
@@ -22,67 +22,9 @@
                 </div>
             </div>
 
-            <!-- 기존 템플릿 내용 삭제 후 정렬을 위한 빈 칸으로 활용 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <%--<div class="footer_title">blog posts</div>
-                    <div class="footer_content footer_blog">
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_1.jpg" alt="https://unsplash.com/@avidenov"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_2.jpg" alt="https://unsplash.com/@deannaritchie"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">New destinations for you</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_3.jpg" alt="https://unsplash.com/@bergeryap87"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                    </div>--%>
-                </div>
-            </div>
-
-
-            <!-- 태그 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <div class="footer_title">태그</div>
-                    <div class="footer_content footer_tags">
-                        <ul class="tags_list clearfix">
-                            <li class="tag_item"><a href="#">바캉스</a></li>
-                            <li class="tag_item"><a href="#">호캉스</a></li>
-                            <li class="tag_item"><a href="#">페스티벌</a></li>
-                            <li class="tag_item"><a href="#">파티</a></li>
-                            <li class="tag_item"><a href="#">프라이빗</a></li>
-                            <li class="tag_item"><a href="#">마운틴뷰</a></li>
-                            <li class="tag_item"><a href="#">시티뷰</a></li>
-                            <li class="tag_item"><a href="#">오션뷰</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-
             <!-- 연락처 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
-                    <div class="footer_title">연락처</div>
                     <div class="footer_content footer_contact">
                         <ul class="contact_info_list">
                             <li class="contact_info_item d-flex flex-row">

--- a/client/src/main/webapp/views/payments/headers.jsp
+++ b/client/src/main/webapp/views/payments/headers.jsp
@@ -43,9 +43,6 @@
                                         <a href="<c:url value="/mypage?name=${sessionScope.user.name}"/> ">${sessionScope.user.name}</a>
                                     </div>
                                     <div class="user_box_login user_box_link">
-                                        <a href="<c:url value="/cart?name=${sessionScope.user.name}"/> ">Cart</a>
-                                    </div>
-                                    <div class="user_box_login user_box_link">
                                         <a href="<c:url value="/auth/logout"/> ">logout</a>
                                     </div>
                                     <div class="user_box_login theme-switch">

--- a/client/src/main/webapp/views/review/footer.jsp
+++ b/client/src/main/webapp/views/review/footer.jsp
@@ -10,7 +10,7 @@
         <div class="row">
 
             <!-- 회사 정보 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
                     <div class="footer_content footer_about">
                         <div class="logo_container footer_logo">
@@ -22,67 +22,9 @@
                 </div>
             </div>
 
-            <!-- 기존 템플릿 내용 삭제 후 정렬을 위한 빈 칸으로 활용 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <%--<div class="footer_title">blog posts</div>
-                    <div class="footer_content footer_blog">
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_1.jpg" alt="https://unsplash.com/@avidenov"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_2.jpg" alt="https://unsplash.com/@deannaritchie"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">New destinations for you</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_3.jpg" alt="https://unsplash.com/@bergeryap87"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                    </div>--%>
-                </div>
-            </div>
-
-
-            <!-- 태그 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <div class="footer_title">태그</div>
-                    <div class="footer_content footer_tags">
-                        <ul class="tags_list clearfix">
-                            <li class="tag_item"><a href="#">바캉스</a></li>
-                            <li class="tag_item"><a href="#">호캉스</a></li>
-                            <li class="tag_item"><a href="#">페스티벌</a></li>
-                            <li class="tag_item"><a href="#">파티</a></li>
-                            <li class="tag_item"><a href="#">프라이빗</a></li>
-                            <li class="tag_item"><a href="#">마운틴뷰</a></li>
-                            <li class="tag_item"><a href="#">시티뷰</a></li>
-                            <li class="tag_item"><a href="#">오션뷰</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-
             <!-- 연락처 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
-                    <div class="footer_title">연락처</div>
                     <div class="footer_content footer_contact">
                         <ul class="contact_info_list">
                             <li class="contact_info_item d-flex flex-row">

--- a/client/src/main/webapp/views/review/headers.jsp
+++ b/client/src/main/webapp/views/review/headers.jsp
@@ -41,9 +41,6 @@
                                     <a href="<c:url value="/mypage?name=${sessionScope.user.name}"/> ">${sessionScope.user.name}</a>
                                 </div>
                                 <div class="user_box_login user_box_link">
-                                    <a href="<c:url value="/cart?name=${sessionScope.user.name}"/> ">Cart</a>
-                                </div>
-                                <div class="user_box_login user_box_link">
                                     <a href="<c:url value="/auth/logout"/> ">logout</a>
                                 </div>
                                 <div class="user_box_login theme-switch">

--- a/client/src/main/webapp/views/roominfo/footer.jsp
+++ b/client/src/main/webapp/views/roominfo/footer.jsp
@@ -9,7 +9,7 @@
         <div class="row">
 
             <!-- 회사 정보 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
                     <div class="footer_content footer_about">
                         <div class="logo_container footer_logo">
@@ -22,67 +22,9 @@
                 </div>
             </div>
 
-            <!-- 기존 템플릿 내용 삭제 후 정렬을 위한 빈 칸으로 활용 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <%--<div class="footer_title">blog posts</div>
-                    <div class="footer_content footer_blog">
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_1.jpg" alt="https://unsplash.com/@avidenov"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_2.jpg" alt="https://unsplash.com/@deannaritchie"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">New destinations for you</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                        <!-- Footer blog item -->
-                        <div class="footer_blog_item clearfix">
-                            <div class="footer_blog_image"><img src="images/footer_blog_3.jpg" alt="https://unsplash.com/@bergeryap87"></div>
-                            <div class="footer_blog_content">
-                                <div class="footer_blog_title"><a href="blog.html">Travel with us this year</a></div>
-                                <div class="footer_blog_date">Nov 29, 2017</div>
-                            </div>
-                        </div>
-
-                    </div>--%>
-                </div>
-            </div>
-
-
-            <!-- 태그 -->
-            <div class="col-lg-3 footer_column">
-                <div class="footer_col">
-                    <div class="footer_title">태그</div>
-                    <div class="footer_content footer_tags">
-                        <ul class="tags_list clearfix">
-                            <li class="tag_item"><a href="#">바캉스</a></li>
-                            <li class="tag_item"><a href="#">호캉스</a></li>
-                            <li class="tag_item"><a href="#">페스티벌</a></li>
-                            <li class="tag_item"><a href="#">파티</a></li>
-                            <li class="tag_item"><a href="#">프라이빗</a></li>
-                            <li class="tag_item"><a href="#">마운틴뷰</a></li>
-                            <li class="tag_item"><a href="#">시티뷰</a></li>
-                            <li class="tag_item"><a href="#">오션뷰</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-
             <!-- 연락처 -->
-            <div class="col-lg-3 footer_column">
+            <div class="col-lg-12 footer_column">
                 <div class="footer_col">
-                    <div class="footer_title">연락처</div>
                     <div class="footer_content footer_contact">
                         <ul class="contact_info_list">
                             <li class="contact_info_item d-flex flex-row">

--- a/client/src/main/webapp/views/roominfo/headers.jsp
+++ b/client/src/main/webapp/views/roominfo/headers.jsp
@@ -36,9 +36,6 @@
                                     <a href="<c:url value="/mypage?name=${sessionScope.user.name}"/> ">${sessionScope.user.name}</a>
                                 </div>
                                 <div class="user_box_login user_box_link">
-                                    <a href="<c:url value="/cart?name=${sessionScope.user.name}"/> ">Cart</a>
-                                </div>
-                                <div class="user_box_login user_box_link">
                                     <a href="<c:url value="/auth/logout"/> ">logout</a>
                                 </div>
                                 <div class="user_box_login theme-switch">

--- a/client/src/main/webapp/views/wishlist/headers.jsp
+++ b/client/src/main/webapp/views/wishlist/headers.jsp
@@ -52,9 +52,6 @@
                                         <a href="<c:url value="/mypage?name=${sessionScope.user.name}"/> ">${sessionScope.user.name}</a>
                                     </div>
                                     <div class="user_box_login user_box_link">
-                                        <a href="<c:url value="/cart?name=${sessionScope.user.name}"/> ">Cart</a>
-                                    </div>
-                                    <div class="user_box_login user_box_link">
                                         <a href="<c:url value="/auth/logout"/> ">logout</a></div>
                                     <div class="user_box_login theme-switch">
                                         <label class="theme-toggle">


### PR DESCRIPTION
이 이슈는 여러 페이지에 걸쳐 푸터의 스타일과 레이아웃을 개선하고 JSP 파일에서 바닥글 구조를 단순화한 작업을 다루고 있습니다. 주요 변경 사항으로는 보다 간결한 디자인을 위해 패딩과 여백을 줄이고, JSP 템플릿에서 중복 섹션을 제거하며, 더 나은 정렬을 위해 단일 열 구조를 사용하도록 레이아웃을 업데이트하는 것 등이 있습니다.

### 스타일링 개선:
* 보다 간결한 레이아웃을 위해 여러 반응형 CSS 파일에서 '.footer_column'의 `여백-하단`을 `60px`에서 `10px`로 줄였습니다. 
* 세로 간격을 줄이고 여러 스타일시트에서 보다 간결한 디자인을 만들기 위해 '.footer`, '.footer_about', '.contact_info_list'의 패딩과 여백을 조정했습니다.

### JSP 템플릿 간소화:
* 바닥글 열을 단일 열(`col-lg-12`)로 통합하고 `about`, `contacts`, `details` 보기에 대한 `footer.jsp` 파일에서 블로그 게시물 및 태그와 같이 사용하지 않는 섹션을 제거했습니다.

* 탐색을 간소화하기 위해 `정보` 및 `연락처` 보기의 JSP 파일 헤더에서 “장바구니” 링크를 제거했습니다.
